### PR TITLE
fix: use YYYY-MM-DD format in time.dateTime

### DIFF
--- a/static-build/pages/index/index.tsx
+++ b/static-build/pages/index/index.tsx
@@ -86,7 +86,7 @@ const IndexPage: FunctionalComponent<Props> = ({
               </h1>
               <time
                 class="article-date"
-                dateTime={date.format(new Date(post.date), 'YYYY-DD-MM')}
+                dateTime={date.format(new Date(post.date), 'YYYY-MM-DD')}
               >
                 Posted {date.format(new Date(post.date), 'DD MMMM YYYY')}{' '}
                 {post.mindframe}

--- a/static-build/pages/post/index.tsx
+++ b/static-build/pages/post/index.tsx
@@ -87,7 +87,7 @@ const PostPage: FunctionalComponent<Props> = ({ post }: Props) => {
             <h1>{post.title}</h1>
             <time
               class="article-date"
-              dateTime={date.format(new Date(post.date), 'YYYY-DD-MM')}
+              dateTime={date.format(new Date(post.date), 'YYYY-MM-DD')}
             >
               Posted {date.format(new Date(post.date), 'DD MMMM YYYY')}{' '}
               {post.mindframe}


### PR DESCRIPTION
The HTML spec defines the value of the datetime attribute has to follow the **datetime value** defined in https://whatwg.org/html#datetime-value .
And it defines the valid date string to be in YYYY-MM-DD format.