### PR TITLE
Change CORB explanation URL

### DIFF
--- a/static-build/posts/2021/10/cors/index.md
+++ b/static-build/posts/2021/10/cors/index.md
@@ -150,7 +150,7 @@ It's become pretty clear that the above was a mistake in the design of the web, 
 
 - CSS from another origin (I'll get to a definition of 'origin' shortly) now needs to be sent with a CSS `Content-Type`. Unfortunately we can't enforce the same thing for scripts and images, or CSS on [quirks mode](https://en.wikipedia.org/wiki/Quirks_mode) pages, without breaking significant portions of the web.
 - The [`X-Content-Type-Options: nosniff` header](https://fetch.spec.whatwg.org/#x-content-type-options-header) lets the server say "hey, don't allow this to be parsed as CSS or JS unless I've sent the right `Content-Type`".
-- Later, the `nosniff` rules were expanded to prevent particular no-CORS response types from another origin, such as HTML, JSON, and XML (except SVG). This protection is called [CORB](https://fetch.spec.whatwg.org/#corb).
+- Later, the `nosniff` rules were expanded to prevent particular no-CORS response types from another origin, such as HTML, JSON, and XML (except SVG). This protection is called [CORB](https://chromium.googlesource.com/chromium/src/+/main/services/network/cross_origin_read_blocking_explainer.md).
 - More recently, we don't send cookies along with the request from site-A to site-B, unless site-B has opted-in using the [`SameSite` cookie attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite). Without cookies, the site generally returns the 'logged-out' view, without private data.
 - Firefox and Safari go a step further, and try to fully isolate sites, although how this works is currently pretty different between the two.
 


### PR DESCRIPTION
The section seems to be gone from https://fetch.spec.whatwg.org/#corb
Chromium docs is the first one I managed to google