### PR TITLE
Fix split typo in "Animating zooming using CSS"

### DIFF
--- a/static-build/posts/2025/06/animating-zooming/index.md
+++ b/static-build/posts/2025/06/animating-zooming/index.md
@@ -314,7 +314,7 @@ Unfortunately, this format is harder to tweak in DevTools, but you can fix that 
 }
 ```
 
-Or even, split the `translate` into two separate properties:
+Or even, split the `transform` into two separate properties:
 
 ```css
 .demo.zoom {


### PR DESCRIPTION
I believe you meant to say "split the `transform`" there. Great post!