### PR TITLE
Fix typo: split `transform`, not `translate`

### DIFF
--- a/static-build/posts/2025/06/animating-zooming/index.md
+++ b/static-build/posts/2025/06/animating-zooming/index.md
@@ -314,7 +314,7 @@ Unfortunately, this format is harder to tweak in DevTools, but you can fix that 
 }
 ```
 
-Or even, split the `translate` into two separate properties:
+Or even, split the `transform` into two separate properties:
 
 ```css
 .demo.zoom {


### PR DESCRIPTION
Hey Jake, great post as usual!

Smol typo fix. At least this is what i understood was meant to be said here.